### PR TITLE
Added some methods that were called but did not exist!

### DIFF
--- a/src/stumpy_core/rgba/from_rgba.cr
+++ b/src/stumpy_core/rgba/from_rgba.cr
@@ -33,11 +33,22 @@ module StumpyCore
     # Shorthand for `from_rgb_n(values, 8)`
     def self.from_rgb8(values)
       r, g, b = values
-      self.from_rgb(r, g, b)
+      self.from_rgb8(r, g, b)
     end
 
     # Shorthand for `from_rgb_n(r, g, b, 8)`
     def self.from_rgb8(r, g, b)
+      from_rgb_n(r, g, b, 8)
+    end
+    
+    # Shorthand for `from_rgb_n(r, g, b, 8)`
+    def self.from_rgb(r, g, b)
+      from_rgb_n(r, g, b, 8)
+    end
+    
+    # Shorthand for `from_rgb_n(values, 8)`
+    def self.from_rgb(values)
+      r, g, b = values
       from_rgb_n(r, g, b, 8)
     end
 
@@ -56,12 +67,23 @@ module StumpyCore
       r, g, b, a = values
       self.from_rgba8(r, g, b, a)
     end
-
+    
     # Shorthand for `from_rgba_n(r, g, b, a, 8)`
     def self.from_rgba8(r, g, b, a)
       from_rgba_n(r, g, b, a, 8)
     end
 
+    # Shorthand for `from_rgba_n(values, 8)`
+    def self.from_rgba(values)
+      r, g, b, a = values
+      self.from_rgba8(r, g, b, a)
+    end
+    
+    # Shorthand for `from_rgba_n(r, g, b, a, 8)`
+    def self.from_rgba(r, g, b, a)
+      from_rgba_n(r, g, b, a, 8)
+    end
+    
     # Create a 8-bit `{r, g, b, a}` tuple.
     def to_rgba
       {


### PR DESCRIPTION
On [line 36](https://github.com/stumpycr/stumpy_core/blob/bf76c5389167228fda47fb15c4487f2777ff9b3e/src/stumpy_core/rgba/from_rgba.cr#L36) of `from_rgb.cr`
https://github.com/stumpycr/stumpy_core/blob/bf76c5389167228fda47fb15c4487f2777ff9b3e/src/stumpy_core/rgba/from_rgba.cr#L36
 `from_rgb` was called, despite there being no such function

caused error
```
in lib/stumpy_core/src/stumpy_core/rgba/from_rgba.cr:36: undefined method 'from_rgb' for StumpyCore::RGBA:Class (did you mean 'from_rgb8'?)

      self.from_rgb(r, g, b)
           ^~~~~~~~
```
Perhaps adding these methods would add convenience.