### PR TITLE
chore(shard.yml): update for crystal 1.0.0 support

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,7 @@
 name: stumpy_core
-version: 1.9.0
+version: 1.9.1
+
+crystal: ">= 0.35.1, < 2.0.0"
 
 authors:
   - Leon Rische <hello@l3kn.de>


### PR DESCRIPTION
currently to use this shard with crystal 1.0.0 you need to `shards install --ignore-crystal-version`