### PR TITLE
Update to Crystal 1.0 and add Canvas#resize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.crystal
 /.shards
-/libs
+/lib
 /tmp
 /docs
+shard.lock

--- a/shard.yml
+++ b/shard.yml
@@ -1,12 +1,7 @@
 name: stumpy_core
 version: 1.9.0
-
+license: MIT
 authors:
   - Leon Rische <hello@l3kn.de>
 
-development_dependencies:
-  minitest:
-    git: https://github.com/ysbaddaden/minitest.cr.git
-    version: ~> 0.3.5
-
-license: MIT
+crystal: "< 2.0.0"

--- a/spec/stumpy_core_spec.cr
+++ b/spec/stumpy_core_spec.cr
@@ -16,7 +16,7 @@ describe StumpyCore do
     describe "map_with_index" do
       it "works as expected" do
         canvas = Canvas.new(10, 10, RGBA::RED)
-        res = canvas.map_with_index {|p, x, y, i| i.even? ? RGBA::BLACK : RGBA::WHITE }
+        res = canvas.map_with_index { |p, x, y, i| i.even? ? RGBA::BLACK : RGBA::WHITE }
         canvas[0, 0].should eq(RGBA::RED)
         canvas[1, 0].should eq(RGBA::RED)
         canvas[0, 1].should eq(RGBA::RED)
@@ -29,10 +29,29 @@ describe StumpyCore do
     describe "map_with_index!" do
       it "works as expected" do
         canvas = Canvas.new(10, 10, RGBA::RED)
-        canvas.map_with_index! {|p, x, y, i| i.even? ? RGBA::BLACK : RGBA::WHITE }
+        canvas.map_with_index! { |p, x, y, i| i.even? ? RGBA::BLACK : RGBA::WHITE }
         canvas[0, 0].should eq(RGBA::BLACK)
         canvas[1, 0].should eq(RGBA::WHITE)
         canvas[0, 1].should eq(RGBA::BLACK)
+      end
+    end
+
+    describe "resize" do
+      it "modifies the canvas" do
+        canvas = Canvas.new(10, 10, RGBA::RED)
+        canvas.resize(2, 2)
+        canvas.width.should eq(2)
+        canvas.height.should eq(2)
+        canvas.pixels.size.should eq(4)
+        canvas[0, 0].should eq(RGBA::RED)
+      end
+
+      it "throws an error if the size is to big" do
+        canvas = Canvas.new(10, 10, RGBA::RED)
+        size = 2**30
+        expect_raises(Exception) do
+          canvas.resize(size, size)
+        end
       end
     end
   end

--- a/src/stumpy_core/rgba/from_hex.cr
+++ b/src/stumpy_core/rgba/from_hex.cr
@@ -25,15 +25,15 @@ module StumpyCore
         b = hex[4].to_i(16)
         from_rgba_n(r, g, b, a, 4)
       when 7
-        r = hex[1,2].to_i(16)
-        g = hex[3,2].to_i(16)
-        b = hex[5,2].to_i(16)
+        r = hex[1, 2].to_i(16)
+        g = hex[3, 2].to_i(16)
+        b = hex[5, 2].to_i(16)
         from_rgb_n(r, g, b, 8)
       when 9
-        a = hex[1,2].to_i(16)
-        r = hex[3,2].to_i(16)
-        g = hex[5,2].to_i(16)
-        b = hex[7,2].to_i(16)
+        a = hex[1, 2].to_i(16)
+        r = hex[3, 2].to_i(16)
+        g = hex[5, 2].to_i(16)
+        b = hex[7, 2].to_i(16)
         from_rgba_n(r, g, b, a, 8)
       else
         raise "Invalid hex color: #{hex}"

--- a/src/stumpy_core/rgba/from_hsl_hsv.cr
+++ b/src/stumpy_core/rgba/from_hsl_hsv.cr
@@ -19,12 +19,12 @@ module StumpyCore
     # Create a RGBA struct
     # from [HLS](https://en.wikipedia.org/wiki/HSL_and_HSV) values
     # and an alpha component.
-    # 
+    #
     # Range of the values:
     # * __h__ue = 0..360
     # * __s__aturaiton = 0..100
     # * __l__ightness = 0..100
-    # * __a__lpha = 0.0..1.0 
+    # * __a__lpha = 0.0..1.0
     def self.from_hsla(h, s, l, alpha)
       h /= 360.0
       s /= 100.0
@@ -66,12 +66,12 @@ module StumpyCore
     # Create a RGBA struct
     # from [HLV](https://en.wikipedia.org/wiki/HSL_and_HSV) values
     # and an alpha component.
-    # 
+    #
     # Range of the values:
     # * __h__ue = 0..360
     # * __s__aturaiton = 0..100
     # * __v__value = 0..100
-    # * __a__lpha = 0.0..1.0 
+    # * __a__lpha = 0.0..1.0
     def self.from_hsva(h, s, v, alpha)
       h /= 360.0
       s /= 100.0
@@ -98,8 +98,8 @@ module StumpyCore
           from_relative(i1, i2, v, alpha)
         when 4
           from_relative(i3, i1, v, alpha)
-        # i == 5 is the only other option
-        # Use `else` instead of `when 5` so the return value can't be `nil`
+          # i == 5 is the only other option
+          # Use `else` instead of `when 5` so the return value can't be `nil`
         else
           from_relative(v, i1, i2, alpha)
         end

--- a/src/stumpy_core/rgba/from_rgba.cr
+++ b/src/stumpy_core/rgba/from_rgba.cr
@@ -40,12 +40,12 @@ module StumpyCore
     def self.from_rgb8(r, g, b)
       from_rgb_n(r, g, b, 8)
     end
-    
+
     # Shorthand for `from_rgb_n(r, g, b, 8)`
     def self.from_rgb(r, g, b)
       from_rgb_n(r, g, b, 8)
     end
-    
+
     # Shorthand for `from_rgb_n(values, 8)`
     def self.from_rgb(values)
       r, g, b = values
@@ -67,7 +67,7 @@ module StumpyCore
       r, g, b, a = values
       self.from_rgba8(r, g, b, a)
     end
-    
+
     # Shorthand for `from_rgba_n(r, g, b, a, 8)`
     def self.from_rgba8(r, g, b, a)
       from_rgba_n(r, g, b, a, 8)
@@ -78,12 +78,12 @@ module StumpyCore
       r, g, b, a = values
       self.from_rgba8(r, g, b, a)
     end
-    
+
     # Shorthand for `from_rgba_n(r, g, b, a, 8)`
     def self.from_rgba(r, g, b, a)
       from_rgba_n(r, g, b, a, 8)
     end
-    
+
     # Create a 8-bit `{r, g, b, a}` tuple.
     def to_rgba
       {

--- a/src/stumpy_core/rgba/mixing.cr
+++ b/src/stumpy_core/rgba/mixing.cr
@@ -53,6 +53,5 @@ module StumpyCore
         RGBA.new(new_r.to_u16, new_g.to_u16, new_b.to_u16, new_a.to_u16)
       end
     end
-
   end
 end


### PR DESCRIPTION
- Added the crystal field to `shard.yml`
- Removed unused minitest dependency
- Ran `crystal tool format`
- Added `Canvas#resize` where you pass in new width and height (followed algorithm found here: https://tech-algorithm.com/articles/nearest-neighbor-image-scaling/)