### PR TITLE
Remove unused minitest dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /libs
 /tmp
 /docs
+shard.lock

--- a/shard.yml
+++ b/shard.yml
@@ -6,9 +6,4 @@ crystal: ">= 0.35.1, < 2.0.0"
 authors:
   - Leon Rische <hello@l3kn.de>
 
-development_dependencies:
-  minitest:
-    git: https://github.com/ysbaddaden/minitest.cr.git
-    version: ~> 0.3.5
-
 license: MIT


### PR DESCRIPTION
Besides being unused, it caused issues with Crystal 1.0