### PR TITLE
Fix equality for non-canvas objects

### DIFF
--- a/spec/stumpy_core_spec.cr
+++ b/spec/stumpy_core_spec.cr
@@ -35,6 +35,34 @@ describe StumpyCore do
         canvas[0, 1].should eq(RGBA::BLACK)
       end
     end
+
+    describe "==" do
+      it "returns true for equivalent canvases" do
+        canvas1 = Canvas.new(10, 10, RGBA::RED)
+        canvas1.map_with_index! {|p, x, y, i| i.even? ? RGBA::BLACK : RGBA::WHITE }
+
+        canvas2 = Canvas.new(10, 10, RGBA::RED)
+        canvas2.map_with_index! {|p, x, y, i| i.even? ? RGBA::BLACK : RGBA::WHITE }
+
+        (canvas1 == canvas2).should be_true
+      end
+
+      it "returns false for different canvases" do
+        canvas1 = Canvas.new(10, 10, RGBA::RED)
+        canvas1.map_with_index! {|p, x, y, i| i.even? ? RGBA::BLACK : RGBA::WHITE }
+
+        canvas2 = Canvas.new(10, 10, RGBA::RED)
+        canvas2.map_with_index! {|p, x, y, i| i.odd? ? RGBA::BLACK : RGBA::WHITE }
+
+        (canvas1 == canvas2).should be_false
+      end
+
+      it "returns false for non-canvas arguments" do
+        canvas = Canvas.new(10, 10, RGBA::RED)
+        
+        (canvas == "definitely not a canvas").should be_false
+      end
+    end
   end
 
   describe RGBA do

--- a/src/stumpy_core/canvas.cr
+++ b/src/stumpy_core/canvas.cr
@@ -179,11 +179,15 @@ module StumpyCore
     # Two canvases are considered equal
     # if they are of equal size
     # and all their pixels are equal
+    def ==(other : self)
+      @width == other.width &&
+      @height == other.height &&
+      @pixels == other.pixels
+    end
+    
+    # :nodoc:
     def ==(other)
-      self.class == other.class &&
-        @width == other.width &&
-        @height == other.height &&
-        @pixels == other.pixels
+      false
     end
 
     # Past the contents of a second `Canvas`


### PR DESCRIPTION
In the current master branch, the following produces a compiler error:

```crystal
require "stumpy_core"

canvas = StumpyCore::Canvas.new(10, 10)
canvas == "test"
```

The error occurs inside `StumpyCore::Canvas#==(other)` as such:
```
Showing last frame. Use --error-trace for full trace.

In src/stumpy_core/canvas.cr:184:25

 184 | @width == other.width &&
                       ^----
Error: undefined method 'width' for String
```

This is because the class checking done in the existing `==` method does not actually restrict the type of `other` before using `Canvas`-specific properties ([code link](https://github.com/stumpycr/stumpy_core/blob/4b86b9faf2f57d8f4a1400917a8fcbb4da1b3c9c/src/stumpy_core/canvas.cr#L179-L187))

I fixed the bug using an overload (Which seems to be the [standard method of doing so](https://github.com/crystal-lang/crystal/blob/6d9a1d5830db5f276bf3df37fceeb0d5333e7e14/src/array.cr#L199-L214)), and added specs.